### PR TITLE
Fix issue with build.bat for paths to source with spaces.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -13,7 +13,7 @@ if not exist %DOTNET_PATH% (
 )
 
 
-%DOTNET_PATH%\msbuild /t:Rebuild /p:Configuration=Release /p:OutputPath=%~dp0\Build %~dp0\OverlayPlugin.sln
+%DOTNET_PATH%\msbuild /t:Rebuild /p:Configuration=Release /p:OutputPath="%~dp0\Build" "%~dp0\OverlayPlugin.sln"
 
 
 :END


### PR DESCRIPTION
Very small fix for cases where the path to the source code has spaces, for example "C:\Source Code\"