### PR TITLE
[WIP] Fix addon loader

### DIFF
--- a/OverlayPlugin/PluginMain.cs
+++ b/OverlayPlugin/PluginMain.cs
@@ -245,13 +245,13 @@ namespace RainbowMage.OverlayPlugin
                         var asm = LoadAssembly(pluginFile);
 
                         // IOverlayAddon を実装した public クラスを列挙し...
-                        var types = asm.GetExportedTypes().Where(t => 
-                                typeof(IOverlayAddon).IsAssignableFrom(t) && t.IsClass);
+                        var types = asm.GetExportedTypes().Where(t =>
+                                t.GetInterface(typeof(IOverlayAddon).FullName) != null && t.IsClass);
                         foreach (var type in types)
                         {
                             try
                             {
-                                if (typeof(IOverlayAddon).IsAssignableFrom(type))
+                                if (type.GetInterface(typeof(IOverlayAddon).FullName) != null)
                                 {
                                     // 各クラスの静的コンストラクタを呼び出す
                                     System.Runtime.CompilerServices.


### PR DESCRIPTION
use GetInterface() instead of IsAssignableFrom()
http://www.hanselman.com/blog/DoesATypeImplementAnInterface.aspx

よくわかりませんが IsAssignableFrom() では IOverlayAddon 実装クラスでもfalseが返ってくるので上記の記事を参考に変えました。

また、addon のアセンブリから OverlayTypeManager.RegisterOverlayType()を呼んでもOverlayPluginのOverlayTypeManagerには登録されませんでした。こちらは未だ解決しておりません。

