### PR TITLE
find the dx11 process in GetGameWindowHandle

### DIFF
--- a/OverlayPlugin.Core/OverlayForm.cs
+++ b/OverlayPlugin.Core/OverlayForm.cs
@@ -483,6 +483,10 @@ namespace RainbowMage.OverlayPlugin
                 if (xivProc == null && DateTime.Now - lastTry > tryInterval)
                 {
                     xivProc = Process.GetProcessesByName("ffxiv").FirstOrDefault();
+                    if (xivProc == null)
+                    {
+                        xivProc = Process.GetProcessesByName("ffxiv_dx11").FirstOrDefault();
+                    }
                     lastTry = DateTime.Now;
                 }
 


### PR DESCRIPTION
This fixes the plugin to remain always on top of the game when it is running in DX11 mode.