### PR TITLE
Fix null object reference after dispose OverlayBase.

### DIFF
--- a/OverlayPlugin.Core/OverlayBase.cs
+++ b/OverlayPlugin.Core/OverlayBase.cs
@@ -294,6 +294,10 @@ namespace RainbowMage.OverlayPlugin
                 {
                     this.timer.Stop();
                 }
+                if (this.xivWindowTimer != null)
+                {
+                    this.xivWindowTimer.Stop();
+                }
                 if (this.Overlay != null)
                 {
                     this.Overlay.Close();


### PR DESCRIPTION
FF14が非アクティブのときに自動的に隠すオプションが有効時、オーバーレイを削除するとNull Object Referenceが発生する問題を修正