### PR TITLE
Stop clicking on an overlay from unfocusing the game

### DIFF
--- a/OverlayPlugin.Core/OverlayForm.cs
+++ b/OverlayPlugin.Core/OverlayForm.cs
@@ -90,10 +90,11 @@ namespace RainbowMage.OverlayPlugin
                 const int WS_EX_TOPMOST = 0x00000008;
                 const int WS_EX_LAYERED = 0x00080000;
                 const int CP_NOCLOSE_BUTTON = 0x200;
+                const int WS_EX_NOACTIVATE = 0x08000000;
 
                 var cp = base.CreateParams;
-                cp.ExStyle = cp.ExStyle | WS_EX_TOPMOST | WS_EX_LAYERED;
-                cp.ClassStyle = cp.ClassStyle | CP_NOCLOSE_BUTTON;
+                cp.ExStyle = cp.ExStyle | WS_EX_TOPMOST | WS_EX_LAYERED | WS_EX_NOACTIVATE;
+                cp.ClassStyle = cp.ClassStyle | CP_NOCLOSE_BUTTON | WS_EX_NOACTIVATE;
 
                 return cp;
             }


### PR DESCRIPTION
With overlays such as [this](https://github.com/IrealiTY/ff14_overlayskin) or [this](https://github.com/Enilia/enilia-overlay/releases) becoming popular losing focus on the game whenever you press something on the overlay is a big annoyance, so simply adding the `WS_EX_NOACTIVATE` flag in the `CreateParams` stops the overlay from gaining focus while still being able to manipulate it.
